### PR TITLE
Change tip card background to orange

### DIFF
--- a/src/components/workout/BJJTab.tsx
+++ b/src/components/workout/BJJTab.tsx
@@ -136,10 +136,10 @@ export const BJJTab = ({ currentDay }: BJJTabProps) => {
             </Card>
 
             {/* Tip informativo */}
-            <div className="mt-4 p-3 bg-blue-900/20 border border-blue-800/30 rounded-lg">
+            <div className="mt-4 p-3 bg-orange-900/20 border border-orange-800/30 rounded-lg">
                 <div className="flex items-start gap-2">
-                    <span className="text-blue-400 text-sm mt-0.5">💡</span>
-                    <div className="text-sm text-blue-300">
+                    <span className="text-orange-400 text-sm mt-0.5">💡</span>
+                    <div className="text-sm text-orange-300">
                         <p className="font-medium mb-1">Tip:</p>
                         <p>Esta es una nota por día de entrenamiento. Para un análisis más efectivo, piensa bien antes de guardar. Si ya tienes una nota para hoy, se reemplazará con la nueva.</p>
                     </div>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Update the 'tip' card background in the BJJ section to orange.

---
[Slack Thread](https://soofiaespacio.slack.com/archives/D098FHVG11D/p1754332944342839?thread_ts=1754332944.342839&cid=D098FHVG11D)

<a href="https://cursor.com/background-agent?bcId=bc-7fe1b838-5964-4fb7-af7a-f4143789c629">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7fe1b838-5964-4fb7-af7a-f4143789c629">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>