### PR TITLE
Update gym and nutrition tips colors

### DIFF
--- a/src/components/nutrition/NutritionSubTabs.tsx
+++ b/src/components/nutrition/NutritionSubTabs.tsx
@@ -50,16 +50,16 @@ export const NutritionSubTabs = ({
                         {children}
 
                         {/* Tips */}
-                        <Card className="bg-gray-900 border-gray-800">
+                        <Card className="bg-orange-600 border-orange-700">
                             <CardHeader className="pb-3">
-                                <CardTitle className="text-sm flex items-center gap-2">
+                                <CardTitle className="text-sm flex items-center gap-2 text-white">
                                     <span>💡</span>
                                     Tips de Preparación
                                 </CardTitle>
                             </CardHeader>
                             <CardContent className="space-y-2">
                                 {getPrepTips(3).map((tip, index) => (
-                                    <div key={index} className="text-xs text-gray-400">
+                                    <div key={index} className="text-xs text-orange-100">
                                         • {tip.replace(/_/g, " ")}
                                     </div>
                                 ))}

--- a/src/components/workout/WorkoutTab.tsx
+++ b/src/components/workout/WorkoutTab.tsx
@@ -137,15 +137,15 @@ export const WorkoutTab = ({
                     </div>
 
                     {/* Guidelines */}
-                    <Card className="mt-6 bg-gray-900 border-gray-800">
+                    <Card className="mt-6 bg-orange-600 border-orange-700">
                         <CardHeader className="pb-3">
-                            <CardTitle className="text-sm">Pautas de Intensidad</CardTitle>
+                            <CardTitle className="text-sm text-white">Pautas de Intensidad</CardTitle>
                         </CardHeader>
                         <CardContent className="space-y-2">
-                            <div className="text-xs text-gray-400">
+                            <div className="text-xs text-orange-100">
                                 <strong>Pausas:</strong> {intensityGuidelines.pausas}
                             </div>
-                            <div className="text-xs text-gray-400">
+                            <div className="text-xs text-orange-100">
                                 <strong>RIR:</strong> {units.rir_definition}
                             </div>
                         </CardContent>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Change background and text color to orange for the "Tips" and "Guidelines" sections in the Nutrition and Workout tabs.

---
[Slack Thread](https://soofiaespacio.slack.com/archives/D098FHVG11D/p1754335382941389?thread_ts=1754335382.941389&cid=D098FHVG11D)

<a href="https://cursor.com/background-agent?bcId=bc-cb6707e7-7b5f-4ab3-ace5-d94cc3b4518c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cb6707e7-7b5f-4ab3-ace5-d94cc3b4518c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>